### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/part3/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/part3/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -63,11 +63,11 @@ public class Article extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/part3/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/part3/fastcampus-project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -52,11 +52,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }


### PR DESCRIPTION
이 pr은 엔티티의 equals(), hashcode()가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

This closes #71 